### PR TITLE
Slice down quick reply options for dates selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -706,7 +706,7 @@ bot.dialog("askDayForGivenTime", [
     session.userData.availableDays.forEach(day =>
       dayStrings.push(day.toLocaleDateString("en-US", dynamicDateOptions))
     );
-    if (dayStrings.length > 10) dayStrings = dayStrings.slice(0, 11);
+    if (dayStrings.length > 3) dayStrings = dayStrings.slice(0, 4);
 
     dayStrings.push("Pick a different time or day");
     if (dayStrings.length === 1) {


### PR DESCRIPTION
facebook messenger doesn't receive the payload of optional dates when given a specific time. might be because the array of options is too large. seeing if solution is to reduce the payload size by slicing the array down further